### PR TITLE
fix: switch to CDN fontawesome 4.x to ensure icons are loaded

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
     - name: 'Download dist/ Artefacts'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: ./dist

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Verify'
         run: make verify
       - name: 'Upload dist/ as artefact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,6 @@ RUN ln -s /app/npm-packages/package.json /app/package.json \
 
 WORKDIR /app
 
-ARG FONTAWESOME_VERSION=6.4.0
-RUN curl --silent --show-error --location --output /tmp/fontawesome.zip \
-    "https://use.fontawesome.com/releases/v${FONTAWESOME_VERSION}/fontawesome-free-${FONTAWESOME_VERSION}-web.zip" \
-  && unzip -q /tmp/fontawesome.zip -d /tmp \
-  && mv /tmp/"fontawesome-free-${FONTAWESOME_VERSION}-web" /app/fontawesome \
-  && rm -rf /tmp/font*
-
 # Install NPM dependencies using the package-lock.json
 RUN { npm install-clean && npx update-browserslist-db@latest; } || npm install
 

--- a/content/attributes.adoc
+++ b/content/attributes.adoc
@@ -3,7 +3,6 @@
 :highlightjsdir: highlightjs
 :highlightjs-languages: groovy, dockerfile
 :icons: font
-:iconfont-remote!:
 :sectids:
 :allow-uri-read:
 :linkattrs:

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -21,7 +21,6 @@ var current_config = {
     buildDir: process.env.BUILD_DIR || '/tmp/dist',
     sourcesDir: '/app/content',
     nodeModulesDir: '/app/node_modules',
-    fontAwesomeDir: '/app/fontawesome',
     listen_ip: process.env.LISTEN_IP || '0.0.0.0',
     listen_port: process.env.LISTEN_PORT || 8000,
     livereload_port: process.env.LIVERELOAD_PORT || 35729,
@@ -50,19 +49,6 @@ function prepare_revealjs_menu_plugin() {
 function prepare_plugin_copycode() {
     return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*')
         .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'));
-}
-
-function prepare_fontawesome() {
-    return src(current_config.fontAwesomeDir + '/css/all.css')
-        // https://github.com/asciidoctor/asciidoctor-reveal.js/issues/286#issuecomment-787081903
-        .pipe(rename('font-awesome.css'))
-        .pipe(dest(current_config.buildDir + '/styles/'));
-}
-
-
-function prepare_webfonts() {
-    return src(current_config.fontAwesomeDir + '/webfonts/**/*')
-        .pipe(dest(current_config.buildDir + '/webfonts/'));
 }
 
 function prepare_highlightjs_min() {
@@ -169,8 +155,6 @@ const build = series(
         prepare_revealjs_external_plugins,
         prepare_revealjs_menu_plugin,
         prepare_plugin_copycode,
-        prepare_fontawesome,
-        prepare_webfonts,
         prepare_highlightjs_min,
         prepare_highlightjs_languages,
         prepare_plugin_clipboardjs,


### PR DESCRIPTION
Since #15 , the fonts are not loading anymore. I tried bumping Fontawesome to latest version or using the NPM package (free for use), but it is failing.

Switching to CDN font as per https://docs.asciidoctor.org/asciidoc/latest/macros/icons-font/ makes it works even though it reverts back to the 4.x line of fontawesome.