### PR TITLE
chore: batch of minor fixes (dependencies, live reload, corrupted files, etc.)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Install latest version of required dependencies
 # hadolint ignore=DL3018

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       -t png -o /app/content/media/qrcode.png ${PRESENTATION_URL}
 
   pdf:
-    image: ghcr.io/astefanutti/decktape:3.7.0
+    image: ghcr.io/astefanutti/decktape:3.14.0
     depends_on:
       build:
         condition: service_completed_successfully # PDF is generated from the dist/index.html

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -26,43 +26,51 @@ var current_config = {
 
 function prepare_revealjs() {
     return src(current_config.nodeModulesDir + '/reveal.js/dist/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/dist/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/dist/'))
+        .pipe(browserSync.stream());;
 }
 
 function prepare_revealjs_core_plugins() {
     return src(current_config.nodeModulesDir + '/reveal.js/plugin/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_revealjs_external_plugins() {
     return src(current_config.nodeModulesDir + '/reveal.js-plugins/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_revealjs_menu_plugin() {
     return src(current_config.nodeModulesDir + '/reveal.js-menu/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/menu/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/menu/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_plugin_copycode() {
     return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*')
-        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'));
+        .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_highlightjs_min() {
     return src(current_config.nodeModulesDir + '/@highlightjs/cdn-assets/highlight.min.js')
-        .pipe(dest(current_config.buildDir + '/highlightjs/'));
+        .pipe(dest(current_config.buildDir + '/highlightjs/'))
+        .pipe(browserSync.stream());
 }
 
 function prepare_highlightjs_languages() {
     return src(current_config.nodeModulesDir + '/@highlightjs/cdn-assets/languages**/*')
-        .pipe(dest(current_config.buildDir + '/highlightjs/'));
+        .pipe(dest(current_config.buildDir + '/highlightjs/'))
+        .pipe(browserSync.stream());
 }
 
 
 function prepare_plugin_clipboardjs() {
     return src(current_config.nodeModulesDir + '/clipboard/dist/clipboard.min.js')
-        .pipe(dest(current_config.buildDir + '/scripts/'));
+        .pipe(dest(current_config.buildDir + '/scripts/'))
+        .pipe(browserSync.stream());
 }
 
 function styles() {
@@ -70,7 +78,8 @@ function styles() {
         .pipe(sass().on('error', sass.logError))
         .pipe(rename('build.css'))
         .pipe(csso())
-        .pipe(dest(current_config.buildDir + '/styles/'));
+        .pipe(dest(current_config.buildDir + '/styles/'))
+        .pipe(browserSync.stream());
 }
 
 function html(cb) {
@@ -92,12 +101,14 @@ function html(cb) {
 
 function media() {
     return src(current_config.mediaSrcPath + '/*', { encoding: false })
-        .pipe(dest(current_config.buildDir + '/media/'));
+        .pipe(dest(current_config.buildDir + '/media/'))
+        .pipe(browserSync.stream());
 }
 
 function favicon() {
     return src(current_config.faviconPath)
-        .pipe(dest(current_config.buildDir + '/'));
+        .pipe(dest(current_config.buildDir + '/'))
+        .pipe(browserSync.stream());
 }
 
 function serve(cb) {
@@ -130,7 +141,7 @@ const watchFiles = function () {
         current_config.stylesSrcPath + '/**/*.scss',
     ], series(styles));
 
-    watch("./*.html").on('change', browserSync.reload);
+    watch(current_config.buildDir + '/*.html').on('change', browserSync.reload);
 }
 
 function clean() {

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -43,7 +43,7 @@ function prepare_revealjs_external_plugins() {
 }
 
 function prepare_revealjs_menu_plugin() {
-    return src(current_config.nodeModulesDir + '/reveal.js-menu/**/*')
+    return src(current_config.nodeModulesDir + '/reveal.js-menu/**/*', { encoding: false })
         .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/menu/'))
         .pipe(browserSync.stream());
 }

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -31,13 +31,13 @@ function prepare_revealjs() {
 }
 
 function prepare_revealjs_core_plugins() {
-    return src(current_config.nodeModulesDir + '/reveal.js/plugin/**/*')
+    return src(current_config.nodeModulesDir + '/reveal.js/plugin/**/*', { encoding: false })
         .pipe(dest(current_config.buildDir + '/reveal.js/plugin/'))
         .pipe(browserSync.stream());
 }
 
 function prepare_revealjs_external_plugins() {
-    return src(current_config.nodeModulesDir + '/reveal.js-plugins/**/*')
+    return src(current_config.nodeModulesDir + '/reveal.js-plugins/**/*', { encoding: false })
         .pipe(dest(current_config.buildDir + '/reveal.js/reveal.js-plugins/'))
         .pipe(browserSync.stream());
 }
@@ -49,7 +49,7 @@ function prepare_revealjs_menu_plugin() {
 }
 
 function prepare_plugin_copycode() {
-    return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*')
+    return src(current_config.nodeModulesDir + '/reveal.js-copycode/plugin/copycode/**/*', { encoding: false })
         .pipe(dest(current_config.buildDir + '/reveal.js/plugin/reveal.js-copycode/'))
         .pipe(browserSync.stream());
 }
@@ -68,7 +68,7 @@ function prepare_highlightjs_languages() {
 
 
 function prepare_plugin_clipboardjs() {
-    return src(current_config.nodeModulesDir + '/clipboard/dist/clipboard.min.js')
+    return src(current_config.nodeModulesDir + '/clipboard/dist/clipboard.min.js', { encoding: false })
         .pipe(dest(current_config.buildDir + '/scripts/'))
         .pipe(browserSync.stream());
 }
@@ -106,7 +106,7 @@ function media() {
 }
 
 function favicon() {
-    return src(current_config.faviconPath)
+    return src(current_config.faviconPath, { encoding: false })
         .pipe(dest(current_config.buildDir + '/'))
         .pipe(browserSync.stream());
 }

--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -1,14 +1,13 @@
-
-
 /*jslint node: true, stupid: true */
+
 const { series, parallel, src, dest, watch } = require('gulp');
 const { exec } = require('child_process');
-var rename = require("gulp-rename");
-var browserSync = require('browser-sync').create();
+const rename = require("gulp-rename");
+const browserSync = require('browser-sync').create();
 const sass = require('gulp-sass')(require('sass'));
 const csso = require('gulp-csso');
-var asciidoctor = require('@asciidoctor/core')();
-var asciidoctorRevealjs = require('@asciidoctor/reveal.js');
+const asciidoctor = require('@asciidoctor/core')();
+const asciidoctorRevealjs = require('@asciidoctor/reveal.js');
 
 asciidoctorRevealjs.register();
 
@@ -74,23 +73,21 @@ function styles() {
         .pipe(dest(current_config.buildDir + '/styles/'));
 }
 
-function html() {
-    return src(current_config.sourcesDir + '/**/*.adoc', { read: false })
-        .on('end', function () {
-            asciidoctor.convertFile(
-                current_config.sourcesDir + '/index.adoc',
-                {
-                    safe: 'unsafe',
-                    backend: 'revealjs',
-                    attributes: {
-                        'revealjsdir': 'node_modules/reveal.js@',
-                        'presentationUrl': process.env.PRESENTATION_URL,
-                        'repositoryUrl': process.env.REPOSITORY_URL,
-                    },
-                    to_dir: current_config.buildDir,
-                }
-            );
-        });
+function html(cb) {
+    asciidoctor.convertFile(
+        current_config.sourcesDir + '/index.adoc',
+        {
+            safe: 'unsafe',
+            backend: 'revealjs',
+            attributes: {
+                'revealjsdir': 'node_modules/reveal.js@',
+                'presentationUrl': process.env.PRESENTATION_URL,
+                'repositoryUrl': process.env.REPOSITORY_URL,
+            },
+            to_dir: current_config.buildDir,
+        }
+    );
+    cb();
 }
 
 function media() {
@@ -159,4 +156,4 @@ const build = series(
 );
 
 exports.build = build;
-exports.default = series(clean, serve, build, watchFiles)
+exports.default = series(clean, build, serve, watchFiles)

--- a/npm-packages/package-lock.json
+++ b/npm-packages/package-lock.json
@@ -11,7 +11,7 @@
                 "@asciidoctor/reveal.js": "5.1.0",
                 "@highlightjs/cdn-assets": "11.10.0",
                 "asciidoctor": "^3.0.4",
-                "browser-sync": "^3.0.2",
+                "browser-sync": "^3.0.3",
                 "clipboard": "2.0.11",
                 "gulp": "5.0.0",
                 "gulp-autoprefixer": "9.0.0",
@@ -24,7 +24,7 @@
                 "reveal.js-copycode": "1.2.0",
                 "reveal.js-menu": "2.1.0",
                 "reveal.js-plugins": "4.2.5",
-                "sass": "^1.78.0"
+                "sass": "^1.80.5"
             }
         },
         "node_modules/@asciidoctor/cli": {
@@ -166,6 +166,292 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/@parcel/watcher": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
+            "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "detect-libc": "^1.0.3",
+                "is-glob": "^4.0.3",
+                "micromatch": "^4.0.5",
+                "node-addon-api": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.4.1",
+                "@parcel/watcher-darwin-arm64": "2.4.1",
+                "@parcel/watcher-darwin-x64": "2.4.1",
+                "@parcel/watcher-freebsd-x64": "2.4.1",
+                "@parcel/watcher-linux-arm-glibc": "2.4.1",
+                "@parcel/watcher-linux-arm64-glibc": "2.4.1",
+                "@parcel/watcher-linux-arm64-musl": "2.4.1",
+                "@parcel/watcher-linux-x64-glibc": "2.4.1",
+                "@parcel/watcher-linux-x64-musl": "2.4.1",
+                "@parcel/watcher-win32-arm64": "2.4.1",
+                "@parcel/watcher-win32-ia32": "2.4.1",
+                "@parcel/watcher-win32-x64": "2.4.1"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+            "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+            "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
+            "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+            "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+            "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+            "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+            "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+            "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+            "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+            "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+            "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+            "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/@socket.io/component-emitter": {
             "version": "3.1.0",
             "dev": true,
@@ -173,11 +459,15 @@
         },
         "node_modules/@types/cookie": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/cors": {
-            "version": "2.8.13",
+            "version": "2.8.17",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+            "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -349,10 +639,11 @@
             }
         },
         "node_modules/assert-never": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
-            "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
-            "dev": true
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.3.0.tgz",
+            "integrity": "sha512-9Z3vxQ+berkL/JJo0dK+EY3Lp0s3NtSnP3VCLsh5HDcZPrh0M+KQRK5sWhUeyPPH+/RCxZqOxLMR+YC6vlviEQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/assign-symbols": {
             "version": "1.0.0",
@@ -386,6 +677,7 @@
             "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
             "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -444,6 +736,7 @@
             "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
             "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.9.6"
             },
@@ -499,6 +792,8 @@
         },
         "node_modules/base64id": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -539,24 +834,27 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/browser-sync": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-3.0.2.tgz",
-            "integrity": "sha512-PC9c7aWJFVR4IFySrJxOqLwB9ENn3/TaXCXtAa0SzLwocLN3qMjN+IatbjvtCX92BjNXsY6YWg9Eb7F3Wy255g==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-3.0.3.tgz",
+            "integrity": "sha512-91hoBHKk1C4pGeD+oE9Ld222k2GNQEAsI5AElqR8iLLWNrmZR2LPP8B0h8dpld9u7kro5IEUB3pUb0DJ3n1cRQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "browser-sync-client": "^3.0.2",
-                "browser-sync-ui": "^3.0.2",
+                "browser-sync-client": "^3.0.3",
+                "browser-sync-ui": "^3.0.3",
                 "bs-recipes": "1.3.4",
                 "chalk": "4.1.2",
                 "chokidar": "^3.5.1",
@@ -570,15 +868,15 @@
                 "fs-extra": "3.0.1",
                 "http-proxy": "^1.18.1",
                 "immutable": "^3",
-                "micromatch": "^4.0.2",
+                "micromatch": "^4.0.8",
                 "opn": "5.3.0",
                 "portscanner": "2.2.0",
                 "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
                 "rx": "4.1.0",
-                "send": "0.16.2",
-                "serve-index": "1.9.1",
-                "serve-static": "1.13.2",
+                "send": "^0.19.0",
+                "serve-index": "^1.9.1",
+                "serve-static": "^1.16.2",
                 "server-destroy": "1.0.1",
                 "socket.io": "^4.4.1",
                 "ua-parser-js": "^1.0.33",
@@ -592,10 +890,11 @@
             }
         },
         "node_modules/browser-sync-client": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.2.tgz",
-            "integrity": "sha512-tBWdfn9L0wd2Pjuz/NWHtNEKthVb1Y67vg8/qyGNtCqetNz5lkDkFnrsx5UhPNPYUO8vci50IWC/BhYaQskDiQ==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-3.0.3.tgz",
+            "integrity": "sha512-TOEXaMgYNjBYIcmX5zDlOdjEqCeCN/d7opf/fuyUD/hhGVCfP54iQIDhENCi012AqzYZm3BvuFl57vbwSTwkSQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "etag": "1.8.1",
                 "fresh": "0.5.2",
@@ -606,10 +905,11 @@
             }
         },
         "node_modules/browser-sync-ui": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.2.tgz",
-            "integrity": "sha512-V3FwWAI+abVbFLTyJjXJlCMBwjc3GXf/BPGfwO2fMFACWbIGW9/4SrBOFYEOOtqzCjQE0Di+U3VIb7eES4omNA==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-3.0.3.tgz",
+            "integrity": "sha512-FcGWo5lP5VodPY6O/f4pXQy5FFh4JK0f2/fTBsp0Lx1NtyBWs/IfPPJbW8m1ujTW/2r07oUXKTF2LYZlCZktjw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "async-each-series": "0.1.1",
                 "chalk": "4.1.2",
@@ -893,6 +1193,7 @@
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
             "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.8"
             }
@@ -914,7 +1215,9 @@
             "dev": true
         },
         "node_modules/cookie": {
-            "version": "0.4.2",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -936,6 +1239,8 @@
         },
         "node_modules/cors": {
             "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1017,9 +1322,15 @@
             }
         },
         "node_modules/destroy": {
-            "version": "1.0.4",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
         },
         "node_modules/detect-file": {
             "version": "1.0.0",
@@ -1028,6 +1339,19 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/dev-ip": {
@@ -1049,7 +1373,8 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
             "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/each-props": {
             "version": "3.0.0",
@@ -1102,7 +1427,9 @@
             "license": "MIT"
         },
         "node_modules/ejs": {
-            "version": "3.1.9",
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1144,7 +1471,9 @@
             }
         },
         "node_modules/engine.io": {
-            "version": "6.5.1",
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
+            "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1153,36 +1482,38 @@
                 "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
                 "base64id": "2.0.0",
-                "cookie": "~0.4.1",
+                "cookie": "~0.7.2",
                 "cors": "~2.8.5",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~5.1.0",
-                "ws": "~8.11.0"
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.17.1"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/engine.io-client": {
-            "version": "6.5.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.3.tgz",
-            "integrity": "sha512-9Z0qLB0NIisTRt1DZ/8U2k12RJn8yls/nXMZLn+/N8hANT3TcYjKFKcwbw5zFQiN4NTde3TSY9zb79e1ij6j9Q==",
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.2.tgz",
+            "integrity": "sha512-TAr+NKeoVTjEVW8P3iHguO1LO6RlUz9O5Y8o7EY0fU+gY1NYqas7NN3slpFtbXEsLMHk0h90fJMfKjRkQ0qUIw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
                 "engine.io-parser": "~5.2.1",
-                "ws": "~8.11.0",
-                "xmlhttprequest-ssl": "~2.0.0"
+                "ws": "~8.17.1",
+                "xmlhttprequest-ssl": "~2.1.1"
             }
         },
         "node_modules/engine.io-client/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -1193,23 +1524,17 @@
                 }
             }
         },
-        "node_modules/engine.io-client/node_modules/engine.io-parser": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
-            "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
         "node_modules/engine.io-client/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/engine.io-parser": {
-            "version": "5.1.0",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+            "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1217,11 +1542,13 @@
             }
         },
         "node_modules/engine.io/node_modules/debug": {
-            "version": "4.3.4",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -1233,7 +1560,9 @@
             }
         },
         "node_modules/engine.io/node_modules/ms": {
-            "version": "2.1.2",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1274,6 +1603,8 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1376,7 +1707,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1444,7 +1777,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.2",
+            "version": "1.15.9",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
             "dev": true,
             "funding": [
                 {
@@ -1498,6 +1833,8 @@
         },
         "node_modules/fresh": {
             "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2126,6 +2463,7 @@
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
             "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2266,6 +2604,8 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2396,7 +2736,8 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
             "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "3.0.1",
@@ -2499,11 +2840,13 @@
             "license": "CC0-1.0"
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -2511,11 +2854,16 @@
             }
         },
         "node_modules/mime": {
-            "version": "1.4.1",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -2560,7 +2908,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
             "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.0.0",
@@ -2604,6 +2953,13 @@
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -5166,7 +5522,7 @@
         },
         "node_modules/npm/node_modules/lodash._baseindexof": {
             "version": "3.1.0",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -5182,19 +5538,19 @@
         },
         "node_modules/npm/node_modules/lodash._bindcallback": {
             "version": "3.0.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/lodash._cacheindexof": {
             "version": "3.0.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/lodash._createcache": {
             "version": "3.1.2",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -5209,7 +5565,7 @@
         },
         "node_modules/npm/node_modules/lodash._getnative": {
             "version": "3.9.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -5227,7 +5583,7 @@
         },
         "node_modules/npm/node_modules/lodash.restparam": {
             "version": "3.6.1",
-            "extraneous": true,
+            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
@@ -7728,12 +8084,13 @@
             }
         },
         "node_modules/pug": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.2.tgz",
-            "integrity": "sha512-bp0I/hiK1D1vChHh6EfDxtndHji55XP/ZJKwsRqrz6lRia6ZC2OZbdAymlxdVFwd1L70ebrVJw4/eZ79skrIaw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
+            "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "pug-code-gen": "^3.0.2",
+                "pug-code-gen": "^3.0.3",
                 "pug-filters": "^4.0.0",
                 "pug-lexer": "^5.0.1",
                 "pug-linker": "^4.0.0",
@@ -7748,6 +8105,7 @@
             "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
             "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "constantinople": "^4.0.1",
                 "js-stringify": "^1.0.2",
@@ -7755,26 +8113,28 @@
             }
         },
         "node_modules/pug-code-gen": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.2.tgz",
-            "integrity": "sha512-nJMhW16MbiGRiyR4miDTQMRWDgKplnHyeLvioEJYbk1RsPI3FuA3saEP8uwnTb2nTJEKBU90NFVWJBk4OU5qyg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
+            "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "constantinople": "^4.0.1",
                 "doctypes": "^1.1.0",
                 "js-stringify": "^1.0.2",
                 "pug-attrs": "^3.0.0",
-                "pug-error": "^2.0.0",
-                "pug-runtime": "^3.0.0",
+                "pug-error": "^2.1.0",
+                "pug-runtime": "^3.0.1",
                 "void-elements": "^3.1.0",
                 "with": "^7.0.0"
             }
         },
         "node_modules/pug-error": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
-            "integrity": "sha512-sjiUsi9M4RAGHktC1drQfCr5C5eriu24Lfbt4s+7SykztEOwVZtbFk1RRq0tzLxcMxMYTBR+zMQaG07J/btayQ==",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
+            "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pug-filters": {
             "version": "4.0.0",
@@ -7834,7 +8194,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
             "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pug-strip-comments": {
             "version": "2.0.0",
@@ -7976,6 +8337,8 @@
         },
         "node_modules/range-parser": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8191,13 +8554,14 @@
             "license": "MIT"
         },
         "node_modules/sass": {
-            "version": "1.78.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.78.0.tgz",
-            "integrity": "sha512-AaIqGSrjo5lA2Yg7RvFZrlXDBCp3nV4XP73GrLGvdRWWwk+8H3l0SDvq/5bA4eF+0RFPLuWUk3E+P1U/YqnpsQ==",
+            "version": "1.80.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.5.tgz",
+            "integrity": "sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "chokidar": ">=3.0.0 <4.0.0",
+                "@parcel/watcher": "^2.4.1",
+                "chokidar": "^4.0.0",
                 "immutable": "^4.0.0",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
@@ -8208,10 +8572,40 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/sass/node_modules/chokidar": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+            "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/sass/node_modules/immutable": {
             "version": "4.3.1",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/sass/node_modules/readdirp": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+            "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
+            }
         },
         "node_modules/select": {
             "version": "1.1.2",
@@ -8242,66 +8636,68 @@
             }
         },
         "node_modules/send": {
-            "version": "0.16.2",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.1.tgz",
+            "integrity": "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
-                "mime": "1.4.1",
-                "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/send/node_modules/depd": {
-            "version": "1.1.2",
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
-        "node_modules/send/node_modules/http-errors": {
-            "version": "1.6.3",
+        "node_modules/send/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/send/node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "ee-first": "1.1.1"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
-        "node_modules/send/node_modules/inherits": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/send/node_modules/setprototypeof": {
-            "version": "1.1.0",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/send/node_modules/statuses": {
-            "version": "1.4.0",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/serve-index": {
@@ -8362,24 +8758,102 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.13.2",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
-                "send": "0.16.2"
+                "parseurl": "~1.3.3",
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-static/node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve-static/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/serve-static/node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve-static/node_modules/send": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/serve-static/node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve-static/node_modules/statuses": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/server-destroy": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
             "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/set-blocking": {
             "version": "2.0.0",
@@ -8409,7 +8883,9 @@
             "license": "ISC"
         },
         "node_modules/socket.io": {
-            "version": "4.7.1",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+            "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8417,31 +8893,60 @@
                 "base64id": "~2.0.0",
                 "cors": "~2.8.5",
                 "debug": "~4.3.2",
-                "engine.io": "~6.5.0",
+                "engine.io": "~6.6.0",
                 "socket.io-adapter": "~2.5.2",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=10.2.0"
             }
         },
         "node_modules/socket.io-adapter": {
-            "version": "2.5.2",
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+            "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ws": "~8.11.0"
+                "debug": "~4.3.4",
+                "ws": "~8.17.1"
             }
         },
-        "node_modules/socket.io-client": {
-            "version": "4.7.5",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
-            "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+        "node_modules/socket.io-adapter/node_modules/debug": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/socket.io-adapter/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/socket.io-client": {
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+            "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.5.2",
+                "engine.io-client": "~6.6.1",
                 "socket.io-parser": "~4.2.4"
             },
             "engines": {
@@ -8449,12 +8954,13 @@
             }
         },
         "node_modules/socket.io-client/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -8466,10 +8972,11 @@
             }
         },
         "node_modules/socket.io-client/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/socket.io-parser": {
             "version": "4.2.4",
@@ -8579,6 +9086,7 @@
             "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
             "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "commander": "^2.2.0",
                 "limiter": "^1.0.5"
@@ -8594,7 +9102,8 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/streamx": {
             "version": "2.16.1",
@@ -8699,6 +9208,8 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8885,6 +9396,8 @@
         },
         "node_modules/vary": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8995,6 +9508,7 @@
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
             "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9016,6 +9530,7 @@
             "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
             "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.9.6",
                 "@babel/types": "^7.9.6",
@@ -9054,7 +9569,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.11.0",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9062,7 +9579,7 @@
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -9074,9 +9591,9 @@
             }
         },
         "node_modules/xmlhttprequest-ssl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
-            "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+            "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"

--- a/npm-packages/package.json
+++ b/npm-packages/package.json
@@ -6,7 +6,7 @@
     "devDependencies": {
         "@asciidoctor/reveal.js": "5.1.0",
         "asciidoctor": "^3.0.4",
-        "browser-sync": "^3.0.2",
+        "browser-sync": "^3.0.3",
         "clipboard": "2.0.11",
         "gulp": "5.0.0",
         "gulp-autoprefixer": "9.0.0",
@@ -20,6 +20,6 @@
         "reveal.js-plugins": "4.2.5",
         "reveal.js-menu": "2.1.0",
         "@highlightjs/cdn-assets": "11.10.0",
-        "sass": "^1.78.0"
+        "sass": "^1.80.5"
     }
 }


### PR DESCRIPTION
This PR introduces a batch of minor fixes to ease our life:

- Fix PDF export on amr64 CPUs by using a recent decktape image
- Fix remaining file corruptions errors (favicon, fonts, etc.) removing all web console warnings
- Fix livereload which wasn't working (broken by #15) by using browserSync properly
- Fix Gulp async issues leading to missed livereload events by signaling completion on the html function
- Bump NodeJS to the new LTS 22.x (active since 29 Oct.)
- Bump NPM dependencies
- Nitpicking on JS linting