### PR TITLE
fix(title) adapt font sizes for title slide

### DIFF
--- a/assets/styles/custom-revealjs.scss
+++ b/assets/styles/custom-revealjs.scss
@@ -12,297 +12,402 @@
  Custom edits
  *********************************************/
 
- .reveal small,
- .reveal .small {
- display: inline-block;
- font-size: 0.6em;
- line-height: 1.2em;
- vertical-align: top; }
+.reveal small,
+.reveal .small {
+  display: inline-block;
+  font-size: 0.6em;
+  line-height: 1.2em;
+  vertical-align: top;
+}
 
- /////// Inverted styles
- .reveal section[data-state="invert"] p,
- .reveal section[data-state="invert"] ul,
- .reveal section[data-state="invert"] li,
- .reveal section[data-state="invert"] small {
-     color: #383D3D; }
- .reveal section[data-state="invert"] h1,
- .reveal section[data-state="invert"] h2,
- .reveal section[data-state="invert"] div.title p {
-   color: #383D3D; }
- .reveal .controls section[data-state="invert"]{
-   color: #383D3D; }
+/////// Inverted styles
+.reveal section[data-state="invert"] p,
+.reveal section[data-state="invert"] ul,
+.reveal section[data-state="invert"] li,
+.reveal section[data-state="invert"] small {
+  color: #383D3D;
+}
 
- /*********************************************
+.reveal section[data-state="invert"] h1,
+.reveal section[data-state="invert"] h2,
+.reveal section[data-state="invert"] div.title p {
+  color: #383D3D;
+}
+
+.reveal .controls section[data-state="invert"] {
+  color: #383D3D;
+}
+
+/*********************************************
   * GLOBAL STYLES
   *********************************************/
 
- .reveal a {
- line-height: 1.3em; }
+.reveal a {
+  line-height: 1.3em;
+}
 
- body {
-   background: #F0F1EB;
-   background-color: #F0F1EB; }
+body {
+  background: #F0F1EB;
+  background-color: #F0F1EB;
+}
 
- .reveal {
-   font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
-   font-size: 32px;
-   font-weight: normal;
-   color: #000; }
+.reveal {
+  font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
+  font-size: 32px;
+  font-weight: normal;
+  color: #000;
+}
 
- ::selection {
-   color: #fff;
-   background: #26351C;
-   text-shadow: none; }
+::selection {
+  color: #fff;
+  background: #26351C;
+  text-shadow: none;
+}
 
- ::-moz-selection {
-   color: #fff;
-   background: #26351C;
-   text-shadow: none; }
+::-moz-selection {
+  color: #fff;
+  background: #26351C;
+  text-shadow: none;
+}
 
- .reveal .slides section,
- .reveal .slides section > section {
-   line-height: 1.3;
-   font-weight: inherit; }
+.reveal .slides section,
+.reveal .slides section>section {
+  line-height: 1.3;
+  font-weight: inherit;
+}
 
- /*********************************************
+/*********************************************
   * HEADERS
   *********************************************/
- .reveal h1,
- .reveal h2,
- .reveal h3,
- .reveal h4,
- .reveal h5,
- .reveal h6 {
-   margin: 0 0 20px 0;
-   color: #383D3D;
-   font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
-   font-weight: normal;
-   line-height: 1.2;
-   letter-spacing: normal;
-   text-transform: none;
-   text-shadow: none;
-   word-wrap: break-word; }
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4,
+.reveal h5,
+.reveal h6 {
+  margin: 0 0 20px 0;
+  color: #383D3D;
+  font-family: "Palatino Linotype", "Book Antiqua", Palatino, FreeSerif, serif;
+  font-weight: normal;
+  line-height: 1.2;
+  letter-spacing: normal;
+  text-transform: none;
+  text-shadow: none;
+  word-wrap: break-word;
+}
 
- .reveal h1 {
-   font-size: 3.77em; }
+.reveal h1 {
+  font-size: 3.2em;
+}
 
- .reveal h2 {
-   font-size: 2.11em; }
+.reveal h2 {
+  font-size: 2.11em;
+}
 
- .reveal h3 {
-   font-size: 1.55em; }
+.reveal h3 {
+  font-size: 1.55em;
+}
 
- .reveal h4 {
-   font-size: 1em; }
+.reveal h4 {
+  font-size: 1em;
+}
 
- .reveal h1 {
-   text-shadow: none; }
+.reveal h1 {
+  text-shadow: none;
+}
 
- /*********************************************
+/*********************************************
   * OTHER
   *********************************************/
- .reveal p {
-   margin: 20px 0;
-   line-height: 1.3; }
+.reveal p {
+  margin: 20px 0;
+  line-height: 1.3;
+}
 
- /* Ensure certain elements are never larger than the slide itself */
- .reveal img,
- .reveal video,
- .reveal iframe {
-   max-width: 95%;
-   max-height: 95%; }
+/* Ensure certain elements are never larger than the slide itself */
+.reveal img,
+.reveal video,
+.reveal iframe {
+  max-width: 95%;
+  max-height: 95%;
+}
 
- .reveal strong,
- .reveal b {
-   font-weight: bold; }
+.reveal strong,
+.reveal b {
+  font-weight: bold;
+}
 
- .reveal em {
-   font-style: italic; }
+.reveal em {
+  font-style: italic;
+}
 
- .reveal ol,
- .reveal dl,
- .reveal ul {
-   display: inline-block;
-   text-align: left;
-   margin: 0 0 0 1em; }
+.reveal ol,
+.reveal dl,
+.reveal ul {
+  display: inline-block;
+  text-align: left;
+  margin: 0 0 0 1em;
+}
 
- .reveal ol {
-   list-style-type: decimal; }
+.reveal ol {
+  list-style-type: decimal;
+}
 
- .reveal ul {
-   list-style-type: disc; }
+.reveal ul {
+  list-style-type: disc;
+}
 
- .reveal ul ul {
-   list-style-type: square; }
+.reveal ul ul {
+  list-style-type: square;
+}
 
- .reveal ul ul ul {
-   list-style-type: circle; }
+.reveal ul ul ul {
+  list-style-type: circle;
+}
 
- .reveal ul ul,
- .reveal ul ol,
- .reveal ol ol,
- .reveal ol ul {
-   display: block;
-   margin-left: 40px; }
+.reveal ul ul,
+.reveal ul ol,
+.reveal ol ol,
+.reveal ol ul {
+  display: block;
+  margin-left: 40px;
+}
 
- .reveal dt {
-   font-weight: bold; }
+.reveal dt {
+  font-weight: bold;
+}
 
- .reveal dd {
-   margin-left: 40px; }
+.reveal dd {
+  margin-left: 40px;
+}
 
- .reveal blockquote {
-   display: block;
-   position: relative;
-   width: 70%;
-   margin: 20px auto;
-   padding: 5px;
-   font-style: italic;
-   background: rgba(255, 255, 255, 0.05);
-   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2); }
+.reveal blockquote {
+  display: block;
+  position: relative;
+  width: 70%;
+  margin: 20px auto;
+  padding: 5px;
+  font-style: italic;
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.2);
+}
 
- .reveal blockquote p:first-child,
- .reveal blockquote p:last-child {
-   display: inline-block; }
+.reveal blockquote p:first-child,
+.reveal blockquote p:last-child {
+  display: inline-block;
+}
 
- .reveal q {
-   font-style: italic; }
+.reveal q {
+  font-style: italic;
+}
 
- .reveal pre {
-   display: block;
-   position: relative;
-   width: 90%;
-   margin: 20px auto;
-   text-align: left;
-   font-size: 0.55em;
-   font-family: monospace;
-   line-height: 1.2em;
-   word-wrap: break-word;
-   box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3); }
+.reveal pre {
+  display: block;
+  position: relative;
+  width: 90%;
+  margin: 20px auto;
+  text-align: left;
+  font-size: 0.55em;
+  font-family: monospace;
+  line-height: 1.2em;
+  word-wrap: break-word;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3);
+}
 
- .reveal code {
-   font-family: monospace;
-   text-transform: none; }
+.reveal code {
+  font-family: monospace;
+  text-transform: none;
+}
 
- .reveal pre code {
-   display: block;
-   padding: 5px;
-   overflow: auto;
-   max-height: 35em;
-   word-wrap: normal; }
+.reveal pre code {
+  display: block;
+  padding: 5px;
+  overflow: auto;
+  max-height: 35em;
+  word-wrap: normal;
+}
 
- .reveal table {
-   margin: auto;
-   border-collapse: collapse;
-   border-spacing: 0; }
+.reveal table {
+  margin: auto;
+  border-collapse: collapse;
+  border-spacing: 0;
+}
 
- .reveal table th {
-   font-weight: bold; }
+.reveal table th {
+  font-weight: bold;
+}
 
- .reveal table th,
- .reveal table td {
-   text-align: left;
-   padding: 0.2em 0.5em 0.2em 0.5em;
-   border-bottom: 1px solid; }
+.reveal table th,
+.reveal table td {
+  text-align: left;
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  border-bottom: 1px solid;
+}
 
- .reveal table th[align="center"],
- .reveal table td[align="center"] {
-   text-align: center; }
+.reveal table th[align="center"],
+.reveal table td[align="center"] {
+  text-align: center;
+}
 
- .reveal table th[align="right"],
- .reveal table td[align="right"] {
-   text-align: right; }
+.reveal table th[align="right"],
+.reveal table td[align="right"] {
+  text-align: right;
+}
 
- .reveal table tbody tr:last-child th,
- .reveal table tbody tr:last-child td {
-   border-bottom: none; }
+.reveal table tbody tr:last-child th,
+.reveal table tbody tr:last-child td {
+  border-bottom: none;
+}
 
- .reveal sup {
-   vertical-align: super;
-   font-size: smaller; }
+.reveal sup {
+  vertical-align: super;
+  font-size: smaller;
+}
 
- .reveal sub {
-   vertical-align: sub;
-   font-size: smaller; }
+.reveal sub {
+  vertical-align: sub;
+  font-size: smaller;
+}
 
- .reveal small {
-   display: inline-block;
-   font-size: 0.6em;
-   line-height: 1.2em;
-   vertical-align: top; }
+.reveal small {
+  display: inline-block;
+  font-size: 0.5em;
+  line-height: 1.2em;
+  vertical-align: top;
+}
 
- .reveal small * {
-   vertical-align: top; }
+.reveal small * {
+  vertical-align: top;
+}
 
- /*********************************************
+/*********************************************
   * LINKS
   *********************************************/
- .reveal a {
-   color: #8b7c69;
-   text-decoration: none;
-   -webkit-transition: color .15s ease;
-   -moz-transition: color .15s ease;
-   transition: color .15s ease; }
+.reveal a {
+  color: #8b7c69;
+  text-decoration: none;
+  -webkit-transition: color .15s ease;
+  -moz-transition: color .15s ease;
+  transition: color .15s ease;
+}
 
- .reveal a:hover {
-   color: rgb(248, 228, 130);
-   text-shadow: none;
-   border: none; }
+.reveal a:hover {
+  color: rgb(248, 228, 130);
+  text-shadow: none;
+  border: none;
+}
 
- .reveal .roll span:after {
-   color: #fff;
-   background: #25211c; }
+.reveal .roll span:after {
+  color: #fff;
+  background: #25211c;
+}
 
- /*********************************************
+/*********************************************
   * IMAGES
   *********************************************/
- .reveal section img {
-   margin: 15px 0px;
-   background: rgba(255, 255, 255, 0.12);
-   border: 0; }
+.reveal section img {
+  margin: 15px 0px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 0;
+}
 
- .reveal section img.plain {
-   border: 0;
-   box-shadow: none; }
+.reveal section img.plain {
+  border: 0;
+  box-shadow: none;
+}
 
- .reveal a img {
-   -webkit-transition: all .15s linear;
-   -moz-transition: all .15s linear;
-   transition: all .15s linear; }
+.reveal a img {
+  -webkit-transition: all .15s linear;
+  -moz-transition: all .15s linear;
+  transition: all .15s linear;
+}
 
- .reveal a:hover img {
-   background: rgba(255, 255, 255, 0.2);
-   border-color: #51483D;
-   box-shadow: 0 0 20px rgba(0, 0, 0, 0.55); }
+.reveal a:hover img {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: #51483D;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.55);
+}
 
- /*********************************************
+/*********************************************
   * NAVIGATION CONTROLS
   *********************************************/
- .reveal .controls {
-   color: #51483D; }
+.reveal .controls {
+  color: #51483D;
+}
 
- /*********************************************
+/*********************************************
   * PROGRESS BAR
   *********************************************/
- .reveal .progress {
-   background: rgba(0, 0, 0, 0.2);
-   color: #51483D; }
+.reveal .progress {
+  background: rgba(0, 0, 0, 0.2);
+  color: #51483D;
+}
 
- .reveal .progress span {
-   -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
-   -moz-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
-   transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985); }
+.reveal .progress span {
+  -webkit-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  -moz-transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+  transition: width 800ms cubic-bezier(0.26, 0.86, 0.44, 0.985);
+}
 
- /*********************************************
+/*********************************************
   * PRINT BACKGROUND
   *********************************************/
- @media print {
-   .backgrounds {
-     background-color: #F0F1EB; } }
+@media print {
+  .backgrounds {
+    background-color: #F0F1EB;
+  }
+}
 
-.reveal pre,.codeblock{
-  width:100%
-}.codeblock{
-  margin:20px auto;
-  position:relative}
-  .codeblock pre{margin:0;width:100%;}.codeblock>button{opacity:0.5;z-index:1;display:block;position:absolute;right:0;top:0;background:orange;color:black;border:0;margin:0;padding:.2em .5em;font-family:inherit;font-size:1rem;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;-webkit-transition:width .5s, background-color .5s, opacity .5s;transition:width .5s, background-color .5s, opacity .5s;cursor:pointer}.codeblock>button:hover,pre>button:hover{opacity:1}.codeblock>button[disabled]{opacity:1;background:green;color:white;cursor:default}.codeblock>button:focus{outline:0}
+.reveal pre,
+.codeblock {
+  width: 100%
+}
+
+.codeblock {
+  margin: 20px auto;
+  position: relative
+}
+
+.codeblock pre {
+  margin: 0;
+  width: 100%;
+}
+
+.codeblock>button {
+  opacity: 0.5;
+  z-index: 1;
+  display: block;
+  position: absolute;
+  right: 0;
+  top: 0;
+  background: orange;
+  color: black;
+  border: 0;
+  margin: 0;
+  padding: .2em .5em;
+  font-family: inherit;
+  font-size: 1rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-transition: width .5s, background-color .5s, opacity .5s;
+  transition: width .5s, background-color .5s, opacity .5s;
+  cursor: pointer
+}
+
+.codeblock>button:hover,
+pre>button:hover {
+  opacity: 1
+}
+
+.codeblock>button[disabled] {
+  opacity: 1;
+  background: green;
+  color: white;
+  cursor: default
+}
+
+.codeblock>button:focus {
+  outline: 0
+}


### PR DESCRIPTION
This PR lints the SCSS styelsheet AND adapts the font size for the title `h1` and the `small` classes to have a better fit on the first slide.

Before:

<img width="1920" alt="Capture d’écran 2024-11-01 à 13 32 38" src="https://github.com/user-attachments/assets/29beb80f-152e-493c-8eb5-9601621468fc">

After:

<img width="1920" alt="Capture d’écran 2024-11-01 à 13 32 31" src="https://github.com/user-attachments/assets/987bfee1-2f6e-4acc-8459-e677bd53654d">
