### PR TITLE
fix(docker/git) re-order chapters for smoother flow

### DIFF
--- a/content/chapitres/ci-nodejs.adoc
+++ b/content/chapitres/ci-nodejs.adoc
@@ -132,5 +132,7 @@ include::../code-samples/gh-actions/ci-nodejs.yml[tags="common,!container,initia
 
 == Checkpoint 🎯
 
-- GitHub Action fournit des actions pour installer et configurer nos environnements de CI
 - Quand le CI est rouge, on le corrige en priorité !
+- Le CI sert de référence pour l'environnement : version des outils, du système
+- CI (execution fréquente) + code (explicite et partagé) pour les outils
+- GitHub Action fournit des actions pour installer et configurer nos environnements de CI

--- a/content/chapitres/docker-network.adoc
+++ b/content/chapitres/docker-network.adoc
@@ -1,6 +1,8 @@
 [{invert}]
 = Docker : Réseau
 
+(chapitre bonus)
+
 == 🤔 Quel est le problème ?
 
 * Comment accéder aux serveurs webs dans des conteneurs ?

--- a/content/index.adoc
+++ b/content/index.adoc
@@ -41,32 +41,33 @@ include::./chapitres/ci.adoc[leveloffset=1]
 // CI avec NodeJS
 include::./chapitres/ci-nodejs.adoc[leveloffset=1]
 
-// Multiplayer Git
-include::./chapitres/moar-git.adoc[leveloffset=1]
-
-// GitHub Forks
-include::./chapitres/github-forks.adoc[leveloffset=1]
-
 // Docker Base
 include::./chapitres/docker-base.adoc[leveloffset=1]
 
 // Docker Images
 include::./chapitres/docker-images.adoc[leveloffset=1]
 
-// CI Docker Images
-include::./chapitres/ci-docker.adoc[leveloffset=1]
-
 // Docker Volumes
 include::./chapitres/docker-volumes.adoc[leveloffset=1]
 
-// Docker Network
-include::./chapitres/docker-network.adoc[leveloffset=1]
+// CI Docker Images
+include::./chapitres/ci-docker.adoc[leveloffset=1]
+
+// Moar Git
+include::./chapitres/moar-git.adoc[leveloffset=1]
+
+// GitHub Forks
+include::./chapitres/github-forks.adoc[leveloffset=1]
 
 // Version
 include::./chapitres/version.adoc[leveloffset=1]
 
 // CD
 include::./chapitres/continuous-delivery.adoc[leveloffset=1]
+
+// Bonus //
+// Docker Network
+include::./chapitres/docker-network.adoc[leveloffset=1]
 
 // Bibliographie
 include::./chapitres/bibliographie.adoc[leveloffset=1]


### PR DESCRIPTION
Comme discuté ensemble, pour que ce soit plus fluide : 

- On inverse les macro section "Docker" et "Git"
  - Docker juste après le "CI avec NodeJS". Comme on finit sur les versions de NodeJS/NPM et environements, Docker est la suite logique
  - Ensuite "Git" pour préparer le terrain aux push/pull / remote / etc.

- Le chapitre "Docker Network" est propulsé à la fin comme "bonus". On verra s'il faut le ramener ou non mais à première vue, tant qu'on ne fait pas de "smoke tests" , pas besoin de comprendre les expositions de ports


=> cette PR est "juste" une inversion". Je vais affiner les les détails dans une PR qui suit